### PR TITLE
Code review [2023-07-26]

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -53,8 +53,7 @@ impl Dispatcher {
         info!("waiting for informant to send protocol range");
         let proto_range = if let Some(range) = source.next().await {
             let range = range.context("failed to read range off connection")?;
-            let Message::Text(range) = range
-                else {
+            let Message::Text(range) = range else {
                 // See nhooyr/websocket's implementation of wsjson.Write
                 unreachable!("informant never sends non-text message")
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,10 @@ impl Args {
 #[allow(non_upper_case_globals)]
 const MiB: u64 = 1 << 20;
 
+// REVIEW: `mib` does not make it clear what the function does. Consider a name that
+// describes the "function" of the function?
+// Or, perhaps use distinct types to represent "number of bytes" vs "number of
+// mebibytes", and then the conversion can be a method (e.g. `to_mib`).
 /// Convert a quantity in bytes to a quantity in mebibytes, generally for display
 /// purposes. (Most calculations in this crate use bytes directly)
 pub fn mib(bytes: u64) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub struct Args {
     #[arg(short, long)]
     file_cache_conn_str: Option<String>,
     #[arg(short, long, default_value_t = String::from("127.0.0.1:10369"))]
-    pub addr: String
+    pub addr: String,
 }
 
 impl Args {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -12,6 +12,8 @@ use axum::extract::ws::{Message, WebSocket};
 use futures_util::{StreamExt, TryFutureExt};
 use tracing::{debug, info, warn};
 
+// REVIEW: this is kind of hard to read.
+// Consider breaking it into multiple `use` statements?
 use crate::{
     cgroup::CgroupState,
     dispatcher::Dispatcher,
@@ -25,6 +27,8 @@ use crate::{
     Args, MiB,
 };
 
+// REVIEW: This whole repo is called `vm-monitor`. Why is this something separate, in
+// a submodule? Is there a better name we could use?
 /// Central struct that interacts with informant, dispatcher, and cgroup to handle
 /// signals from the informant.
 #[derive(Debug)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,5 @@
+// REVIEW: "module for" is redundant
+// REVIEW: "types that ... - types ..." is repetitive; go with the second one.
 //! Module for types that interface with the informant - types representing
 //! protocols and types for actual messages sent to the informant.
 //!
@@ -56,6 +58,15 @@ impl MonitorMessage {
 /// The different underlying message types we can send to the informant.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
+// REVIEW: `MonitorMessageInner` is quite long. I would recommend renaming
+// `MonitorMessage`/`MonitorMessageInner` to one of:
+//
+//  * `MonitorMessage` / `MonitorMessageKind`
+//  * `OutboundMessage` / `OutboundMessageKind`
+//
+// (the reason to use "outbound" instead of "monitor" is because it makes the
+// direction of the flow clear.)
+// You might also like to use 'Msg' instead of 'Message', as an abbreviation :)
 pub enum MonitorMessageInner {
     /// Indicates that the informant sent an invalid message, i.e, we couldn't
     /// properly deserialize it.
@@ -76,6 +87,12 @@ pub enum MonitorMessageInner {
     /// However, if we are simply unsuccessful (for example, do to needing the resources),
     /// that gets included in the `DownscaleResult`.
     DownscaleResult {
+        // REVIEW: I don't think it's as simple as you've highlighted here because
+        // the monitor will still be *sending* this type. It's worth having the
+        // context here though. I'd specifically name the type used on the
+        // agent/informant side. If there's a relevant issue, feel free to link it -
+        // that's more likely to stay up to date with future plans.
+        // ---
         // FIXME for the future (once the informant is deprecated)
         // As of the time of writing, the informant also uses a struct on the go
         // side called DownscaleResult. This struct has uppercase fields which are
@@ -100,6 +117,9 @@ pub struct InformantMessage {
 /// The different underlying message types we can receive from the informant.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", content = "content")]
+// REVIEW: Same thing here about the length of the type name - do you really want to
+// type that everywhere?
+// This is another case where e.g. `InboundMessageKind` might be nice :)
 pub enum InformantMessageInner {
     /// Indicates that the we sent an invalid message, i.e, we couldn't
     /// properly deserialize it.
@@ -119,6 +139,7 @@ pub enum InformantMessageInner {
 
 /// Represents the resources granted to a VM.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+// REVIEW: it's ok to have >1 word! this type is resources! include it in the name!
 pub struct Allocation {
     /// Number of vCPUs
     pub(crate) cpu: f64,
@@ -135,6 +156,9 @@ impl Allocation {
 pub const PROTOCOL_MIN_VERSION: ProtocolVersion = ProtocolVersion::V1_0;
 pub const PROTOCOL_MAX_VERSION: ProtocolVersion = ProtocolVersion::V1_0;
 
+// REVIEW: AFAICT this will prevent adding new protocol versions because they'd need
+// to be recognized here, right? Consider defining ProtocolVersion as a newtype'd
+// `u8` with constants for V1_0, etc. The `match` in the Display impl will still work :)
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum ProtocolVersion {
@@ -155,6 +179,13 @@ impl fmt::Display for ProtocolVersion {
 /// A set of protocol bounds that determines what we are speaking. An invariant
 /// that must be maintained is that min <= max. These bounds are inclusive.
 #[derive(Deserialize, Debug)]
+// REVIEW: You say that there's an invariant here, but also derive Deserialize, which
+// could violate that. I would recommend dropping the invariant and making the fields
+// public (or something) - *in addition* to validating that `min <= max` during
+// deserialization. see e.g. https://github.com/serde-rs/serde/pull/1858#pullrequestreview-575089757
+//
+// Then, the only `ProtocolRange` values you'll have would either be deserialized
+// (guaranteed to be ok) or constants [see comment in src/dispatcher.rs]
 pub struct ProtocolRange {
     min: ProtocolVersion,
     max: ProtocolVersion,
@@ -172,6 +203,8 @@ impl fmt::Display for ProtocolRange {
 
 impl ProtocolRange {
     /// Create a new `ProtocolBounds`. Returns None if min > max
+    // REVIEW: "ProtocolBounds" - old name?
+    // REVIEW: see other note above about dropping the invariant.
     pub fn new(min: ProtocolVersion, max: ProtocolVersion) -> Option<Self> {
         if min > max {
             None
@@ -181,6 +214,7 @@ impl ProtocolRange {
     }
 
     /// Merge to `ProtocolBounds` to create a range that suitable for both of them.
+    // REVIEW: "create a range" - that's not what this function, does, is it?
     pub fn highest_shared_version(&self, other: &Self) -> anyhow::Result<ProtocolVersion> {
         // We first have to make sure the ranges are overlapping. Once we know
         // this, we can merge the ranges by taking the max of the mins and the
@@ -206,6 +240,17 @@ impl ProtocolRange {
 /// An enum in disguise for returning the settled on protocol with the informant.
 /// If error is None, version should be Some and vice versa. It's set up this way
 /// to ease usage on the go side.
+// REVIEW: Does it have to be defined like this? Could the following work?
+//
+//   #[derive(Serialize)]
+//   #[serde(rename_all = "camelCase")]
+//   pub enum ProtocolResponse {
+//       Error(String),
+//       Version(ProtocolVersion),
+//   }
+//
+// see also: https://serde.rs/enum-representations.html
+// NB: "externally tagged" is the default.
 #[derive(Serialize, Debug)]
 pub struct ProtocolResponse {
     error: Option<String>,


### PR DESCRIPTION
One of the big things that I have re-learned from looking at this is that it was easy for the bad architecture of the informant to hide in the flood of low-level control flow operations (that were there because working with channels is actually hard in Go!). The Rust code does not allow the reader to suffer from any such delusions :sweat_smile:

---

Anyways, some initial review. Any reading order should suffice; I'd recommend reading all of it before making changes though.

All review commentary is tagged with "REVIEW". I also made some minor changes to e.g. fix typos.

Broadly there's a lot of places where the code could use comments. I'd re-read the contents of the informant to add some of the explanatory comments that have been omitted, because a lot of the code can actually be quite difficult to understand without that.

---

As you work through these: Decide on a system up-front. If you try to do something ad-hoc to try to remember to get everything, you'll end up missing something. Such are the difficulties of reviewing without a review UI :upside_down_face: — I considered creating an empty and making a PR into that to review off of, but... that seemed a bit hacky.

If I were doing this, I'd `git checkout origin/sharnoff/review-2023-07-26`, then `git reset main` to keep the working tree from the branch but the commits from main, and then poke around in my editor to have gitgutter point out the places where comments/changes were made. It's not perfect, because it's harder to see the previous content side-by-side in the cases where I did make a change, but... food for thought perhaps.